### PR TITLE
Updating atomic-openshift-node-problem-detector builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/k8s.io/node-problem-detector
 COPY . .
 RUN yum install -y systemd-devel && \
     make build-binaries
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 COPY --from=builder /go/src/k8s.io/node-problem-detector/bin/node-problem-detector /usr/bin/
 COPY --from=builder /go/src/k8s.io/node-problem-detector/bin/log-counter /usr/bin/


### PR DESCRIPTION
Updating atomic-openshift-node-problem-detector builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/atomic-openshift-node-problem-detector.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
